### PR TITLE
Rename PARIOThreads to IOThreads

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ minibone is an easy to use yet powerful boiler plate for multithreading, multipr
 
 - __Config__: To handle configuration settings
 - __Daemon__: To run a periodical task in another thread
-- __Emailer__: To send emails in parallel threads
+- __Emailer__: To send emails in concurrent threads
 - __HTMLBase__: To render html using snippets and toml configuration file in async mode
-- __HTTPt__: HTTP client to do parallel request in threads
+- __HTTPt__: HTTP client to do concurrent requests in threads
 - __Logging__: To setup a logger friendly with filerotation
-- __PARThreads__: To run concurrent tasks in threads
+- __IOThreads__: To run concurrent tasks in threads
 - __PARProcesses__: To run parallel CPU-bound tasks
 - __Storing__: To queue and store files periodically in a thread (queue and forget)
 

--- a/src/minibone/httpt.py
+++ b/src/minibone/httpt.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 import httpx
 
-from minibone.io_threads import PARIOThreads
+from minibone.io_threads import IOThreads
 
 
 class Verbs(Enum):
@@ -29,11 +29,11 @@ class HTTPt:
 
     Basic Usage:
     -----------
-    from minibone.io_threads import PARIOThreads
+    from minibone.io_threads import IOThreads
     from minibone.httpt import HTTPt
 
     # Initialize worker and client
-    worker = PARIOThreads()
+    worker = IOThreads()
     client = HTTPt(worker)
 
     # Queue requests
@@ -67,18 +67,18 @@ class HTTPt:
     - Default User-Agent header is set
     """
 
-    def __init__(self, worker: PARIOThreads, timeout: int = 5, headers: dict = None):
+    def __init__(self, worker: IOThreads, timeout: int = 5, headers: dict = None):
         """Initialize HTTP client.
 
         Args:
-            worker: PARIOThreads instance to handle parallel execution
+            worker: IOThreads instance to handle parallel execution
             timeout: Request timeout in seconds (default: 5)
             headers: Optional dictionary of headers to add to requests
 
         Note:
             The worker is ready to process requests immediately after initialization
         """
-        assert isinstance(worker, PARIOThreads)
+        assert isinstance(worker, IOThreads)
         assert isinstance(timeout, int) and timeout > 0
         self._logger = logging.getLogger(__class__.__name__)
 

--- a/src/minibone/io_threads.py
+++ b/src/minibone/io_threads.py
@@ -10,7 +10,7 @@ from threading import Lock
 from typing import Any
 
 
-class PARIOThreads:
+class IOThreads:
     """
     Async manager for concurrent IO-bound tasks using ThreadPoolExecutor.
 
@@ -26,14 +26,14 @@ class PARIOThreads:
 
     Example:
         >>> import asyncio
-        >>> from minibone.io_threads import PARIOThreads
+        >>> from minibone.io_threads import IOThreads
         >>>
         >>> def read_file(filename):
         ...     with open(filename, 'r') as f:
         ...         return f.read()
         ...
         >>> async def main():
-        ...     mgr = PARIOThreads()
+        ...     mgr = IOThreads()
         ...     tid = mgr.submit(read_file, 'example.txt')
         ...     result = await mgr.aresult(tid)
         ...     print(result)

--- a/tests/test_httpt.py
+++ b/tests/test_httpt.py
@@ -6,13 +6,13 @@ import httpx
 
 from minibone.httpt import HTTPt
 from minibone.httpt import Verbs
-from minibone.io_threads import PARIOThreads
+from minibone.io_threads import IOThreads
 
 
 class TestHTTPt(unittest.TestCase):
     def setUp(self) -> None:
         """Set up test worker and client."""
-        self.worker = PARIOThreads()
+        self.worker = IOThreads()
         self.client = HTTPt(worker=self.worker)
 
     def tearDown(self) -> None:


### PR DESCRIPTION
Rename PARIOThreads to IOThreads for consistency and clarity across the codebase